### PR TITLE
Fixed Zend_Filter_BaseName class not found error

### DIFF
--- a/Controller/Adminhtml/Download/AbstractLog.php
+++ b/Controller/Adminhtml/Download/AbstractLog.php
@@ -5,7 +5,6 @@ use Magento\Backend\App\Action\Context;
 use Magento\Backend\Controller\Adminhtml\System;
 use Magento\Framework\App\Response\Http\FileFactory;
 use Magento\Framework\Exception\NotFoundException;
-use Zend_Filter_BaseName;
 
 abstract class AbstractLog extends System
 {
@@ -24,8 +23,7 @@ abstract class AbstractLog extends System
         $param = $this->getRequest()->getParams();
         $filePath = $this->getFilePathWithFile($param[0]);
 
-        $filter   = new Zend_Filter_BaseName();
-        $fileName = $filter->filter($filePath);
+        $fileName = basename($filePath);
         try {
             return $this->fileFactory->create(
                 $fileName,


### PR DESCRIPTION
After updating Magento, an error is produced when attempting to download a log:

`Error: Class "PhilTurner\LogViewer\Controller\Adminhtml\Download\Zend_Filter_BaseName" not found in /var/www/html/ibode/app/code/PhilTurner/LogViewer/Controller/Adminhtml/Download/AbstractLog.php:26`

This is due to the fact that the `Zend_Filter_BaseName` class no longer exists so I fixed it by replacing the class with PHP's `basename()` internal function. 